### PR TITLE
Add ability to use IAM role from EC2 instance for AWS S3 credentials

### DIFF
--- a/ARTIFACT_REPO.md
+++ b/ARTIFACT_REPO.md
@@ -32,7 +32,7 @@ Create a bucket named `my-bucket` from the Minio UI.
 
 ## Configuring AWS S3
 
-Create your bucket and access keys for the bucket. AWS access keys have the same permissions as the user they are associated with. In particular, you cannot create access keys with reduced scope. If you want to limit the permissions for an access key, you will need to create a user with just the permissions you want to associate with the access key. Otherwise, you can just create an access key using your esiting user account.
+Create your bucket and access keys for the bucket. AWS access keys have the same permissions as the user they are associated with. In particular, you cannot create access keys with reduced scope. If you want to limit the permissions for an access key, you will need to create a user with just the permissions you want to associate with the access key. Otherwise, you can just create an access key using your existing user account.
 
 ```
 $ export mybucket=bucket249
@@ -58,7 +58,7 @@ $ aws iam create-access-key --user-name $mybucket-user > access-key.json
 ```
 
 
-NOTE: if you want argo to figure out which region your buckets belong in, you must additionally set the following statement policy. Otherwise, you must specificy a bucket region in your workflow configuration.
+NOTE: if you want argo to figure out which region your buckets belong in, you must additionally set the following statement policy. Otherwise, you must specify a bucket region in your workflow configuration.
 
 ```
     ...
@@ -94,6 +94,8 @@ Use the `endpoint` corresponding to your S3 provider:
 The `key` is name of the object in the `bucket` The `accessKeySecret` and `secretKeySecret` are secret selectors that reference the specified kubernetes secret.  The secret is expected to have have the keys 'accessKey' and 'secretKey', containing the base64 encoded credentials to the bucket.
 
 For AWS, the `accessKeySecret` and `secretKeySecret` correspond to AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY respectively.
+
+EC2 provides a metadata API via which applications using the AWS SDK may assume IAM roles associated with the instance. If you are running argo on EC2 and the instance role allows access to your S3 bucket, you can configure the workflow step pods to assume the role. To do so, simply omit the `accessKeySecret` and `secretKeySecret` fields.
 
 For GCS, the `accessKeySecret` and `secretKeySecret` for S3 compatible access can be obtained from the GCP Console. Note that S3 compatible access is on a per project rather than per bucket basis.
 - Navigate to Storage > Settings (https://console.cloud.google.com/storage/settings).
@@ -131,7 +133,7 @@ The `endpoint`, `accessKeySecret` and `secretKeySecret` are the same as for conf
 ```
   templates:
   - name: artifact-example
-    inputs: 
+    inputs:
       artifacts:
       - name: my-input-artifact
         path: /my-input-artifact
@@ -152,7 +154,7 @@ The `endpoint`, `accessKeySecret` and `secretKeySecret` are the same as for conf
         s3:
           endpoint: storage.googleapis.com
           bucket: my-aws-bucket-name
-          # NOTE that all output artifacts are automatically tarred and 
+          # NOTE that all output artifacts are automatically tarred and
           # gzipped before saving. So as a best practice, .tgz or .tar.gz
           # should be incorporated into the key name so the resulting file
           # has an accurate file extension.

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -291,14 +291,21 @@ func (we *WorkflowExecutor) SaveParameters() error {
 // InitDriver initializes an instance of an artifact driver
 func (we *WorkflowExecutor) InitDriver(art wfv1.Artifact) (artifact.ArtifactDriver, error) {
 	if art.S3 != nil {
-		accessKey, err := we.getSecrets(we.Namespace, art.S3.AccessKeySecret.Name, art.S3.AccessKeySecret.Key)
-		if err != nil {
-			return nil, err
+		var accessKey string
+		var secretKey string
+
+		if art.S3.AccessKeySecret.Name != "" {
+			var err error
+			accessKey, err = we.getSecrets(we.Namespace, art.S3.AccessKeySecret.Name, art.S3.AccessKeySecret.Key)
+			if err != nil {
+				return nil, err
+			}
+			secretKey, err = we.getSecrets(we.Namespace, art.S3.SecretKeySecret.Name, art.S3.SecretKeySecret.Key)
+			if err != nil {
+				return nil, err
+			}
 		}
-		secretKey, err := we.getSecrets(we.Namespace, art.S3.SecretKeySecret.Name, art.S3.SecretKeySecret.Key)
-		if err != nil {
-			return nil, err
-		}
+
 		driver := s3.S3ArtifactDriver{
 			Endpoint:  art.S3.Endpoint,
 			AccessKey: accessKey,


### PR DESCRIPTION
**What**
- When static credentials are not provided in the configmap or workflow configuration, fetch credentials for IAM role from EC2 endpoint.

**Why**
Provide flexibility in configuring S3 secrets.

**Testing**
Given the current implementation, unit testing is not possible without a significant refactoring of the S3 driver to allow for dependency injection.
All current UTs pass.

Locally, testing may be performed by deploying https://github.com/jtblin/aws-mock-metadata configured with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` if expiring credentials are being used.