### PR TITLE
Add ability to pass pod annotations and labels at the template level

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -700,6 +700,9 @@
           "description": "Inputs describe what inputs parameters and artifacts are supplied to this template",
           "$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Inputs"
         },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
         "name": {
           "description": "Name is the name of the template",
           "type": "string"

--- a/examples/pod-metadata.yaml
+++ b/examples/pod-metadata.yaml
@@ -1,0 +1,32 @@
+# This template demonstrates a how pod annotations and labels may be set at the template level
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-
+spec:
+  entrypoint: hello-hello-hello
+
+  templates:
+  - name: hello-hello-hello
+    steps:
+    - - name: hello1
+        template: whalesay
+        arguments:
+          parameters:
+          - name: message
+            value: "hello1"
+
+  - name: whalesay
+    inputs:
+      parameters:
+      - name: message
+    container:
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["{{inputs.parameters.message}}"]
+    metadata:
+      annotations:
+        iam.amazonaws.com/role: role-arn
+      labels:
+        app: whalesay
+        tier: demo

--- a/pkg/apis/workflow/v1alpha1/types.go
+++ b/pkg/apis/workflow/v1alpha1/types.go
@@ -140,6 +140,9 @@ type Template struct {
 	// Overrides the affinity set at the workflow level (if any)
 	Affinity *apiv1.Affinity `json:"affinity,omitempty"`
 
+	// Metdata sets the pods's metadata, i.e. annotations and labels
+	Metadata Metadata `json:"metadata,omitempty"`
+
 	// Deamon will allow a workflow to proceed to the next step so long as the container reaches readiness
 	Daemon *bool `json:"daemon,omitempty"`
 
@@ -195,6 +198,12 @@ type Inputs struct {
 
 	// Artifact are a list of artifacts passed as inputs
 	Artifacts []Artifact `json:"artifacts,omitempty"`
+}
+
+// Pod metdata
+type Metadata struct {
+	Annotations map[string]string `json"annotations,omitempty"`
+	Labels      map[string]string `json"labels,omitempty"`
 }
 
 // Parameter indicate a passed string parameter to a service template with an optional default value

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -28,6 +28,13 @@ spec:
   entrypoint: whalesay
   templates:
   - name: whalesay
+    metadata:
+      annotations:
+        annotationKey1: "annotationValue1"
+        annotationKey2: "annotationValue2"
+      labels:
+        labelKey1: "labelValue1"
+        labelKey2: "labelValue2"
     container:
       image: docker/whalesay:latest
       command: [cowsay]

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -165,6 +165,7 @@ func (woc *wfOperationCtx) createWorkflowPod(nodeName string, mainCtr apiv1.Cont
 	}
 
 	addSchedulingConstraints(&pod, wfSpec, tmpl)
+	addMetadata(&pod, tmpl)
 
 	err = addVolumeReferences(&pod, wfSpec, tmpl, woc.wf.Status.PersistentVolumeClaims)
 	if err != nil {
@@ -276,6 +277,17 @@ func (woc *wfOperationCtx) newExecContainer(name string, privileged bool) *apiv1
 		exec.Resources = *woc.controller.Config.ExecutorResources
 	}
 	return &exec
+}
+
+// addMetadata applies metadata specified in the template
+func addMetadata(pod *apiv1.Pod, tmpl *wfv1.Template) {
+	for k, v := range tmpl.Metadata.Annotations {
+		pod.ObjectMeta.Annotations[k] = v
+	}
+
+	for k, v := range tmpl.Metadata.Labels {
+		pod.ObjectMeta.Labels[k] = v
+	}
 }
 
 // addSchedulingConstraints applies any node selectors or affinity rules to the pod, either set in the workflow or the template

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -142,3 +142,22 @@ func TestTolerations(t *testing.T) {
 	assert.NotNil(t, pod.Spec.Tolerations)
 	assert.Equal(t, pod.Spec.Tolerations[0].Key, "nvidia.com/gpu")
 }
+
+// TestMetadata verifies ability to carry forward annotations and labels
+func TestMetadata(t *testing.T) {
+	woc := newWoc()
+	woc.executeContainer(woc.wf.Spec.Entrypoint, &woc.wf.Spec.Templates[0], "")
+	podName := getPodName(woc.wf)
+	pod, err := woc.controller.kubeclientset.CoreV1().Pods("").Get(podName, metav1.GetOptions{})
+
+	assert.Nil(t, err)
+	assert.NotNil(t, pod.ObjectMeta)
+	assert.NotNil(t, pod.ObjectMeta.Annotations)
+	assert.NotNil(t, pod.ObjectMeta.Labels)
+	for k, v := range woc.wf.Spec.Templates[0].Metadata.Annotations {
+		assert.Equal(t, pod.ObjectMeta.Annotations[k], v)
+	}
+	for k, v := range woc.wf.Spec.Templates[0].Metadata.Labels {
+		assert.Equal(t, pod.ObjectMeta.Labels[k], v)
+	}
+}


### PR DESCRIPTION
**What**
- Add ability to set `template.metadata.annotations` and `template.metadata.labels` as pod metadata

**Why**
Labels are helpful when searching for k8s resources.

Annotations are another type of metadata k8s supports. They can be used by various tools like [kube2iam](https://github.com/jtblin/kube2iam).

**Testing**
Add metadata to templates. Submit job. Test annotations and labels were added with `kubectl describe pod <pod-name>`. See `examples/pod-metadata.yaml`.

**Who**
@malexovi @yayalice 
cc: @darend @dominicbueno 